### PR TITLE
Fix(CI/CD): How slack handles the channel id in the workflow

### DIFF
--- a/.github/workflows/deploy-test-and-notify-for-dev.yml
+++ b/.github/workflows/deploy-test-and-notify-for-dev.yml
@@ -32,12 +32,12 @@ jobs:
 
       - name: Notify Slack if tests fail
         if: steps.test.outcome == 'failure'
-        uses: slackapi/slack-github-action@v1.25.0
+        uses: abinoda/slack-action@master
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
-          payload: |
+          args: >-
             {
               "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
               "text": ":x: *Frontend Dev CI:* Tests failed.\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow>"
             }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This updates the slack function in the workflow and fixes the bug, where slack can't access the channel ID in the payload. 